### PR TITLE
[Feat] application.yml 및 Swagger 명세 구체화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,23 +24,43 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.hibernate:hibernate-spatial:6.4.4.Final'
-	implementation 'org.locationtech.jts:jts-core:1.19.0'
-	implementation 'org.orbisgis:h2gis:1.5.0'
-	implementation 'org.hibernate:hibernate-spatial:6.2.6.Final'
-	implementation 'org.locationtech.jts:jts-core:1.18.2'
+
+	// Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	// Spring Data JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// Devtools
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+	// Thymeleaf
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Spatial
+	implementation 'org.hibernate:hibernate-spatial:6.6.15.Final'
+	implementation 'org.locationtech.jts:jts-core:1.20.0'
+
+	// h2
 	runtimeOnly 'com.h2database:h2'
+	implementation 'org.orbisgis:h2gis:1.5.0'
+
+	// PostgreSQL
+	runtimeOnly 'org.postgresql:postgresql'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'		// swagger
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,9 +34,6 @@ dependencies {
 	// Devtools
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
-	// Thymeleaf
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/src/main/java/com/example/BarrierKU/common/annotation/CustomExceptionDescription.java
+++ b/src/main/java/com/example/BarrierKU/common/annotation/CustomExceptionDescription.java
@@ -1,0 +1,2 @@
+package com.example.BarrierKU.common.config;public @interface CustomExceptionDescription {
+}

--- a/src/main/java/com/example/BarrierKU/common/annotation/CustomExceptionDescription.java
+++ b/src/main/java/com/example/BarrierKU/common/annotation/CustomExceptionDescription.java
@@ -1,2 +1,15 @@
-package com.example.BarrierKU.common.config;public @interface CustomExceptionDescription {
+package com.example.BarrierKU.common.annotation;
+
+import com.example.BarrierKU.common.swagger.SwaggerResponseDescription;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomExceptionDescription {
+
+    SwaggerResponseDescription value();
 }

--- a/src/main/java/com/example/BarrierKU/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/BarrierKU/common/config/SwaggerConfig.java
@@ -1,15 +1,32 @@
 package com.example.BarrierKU.common.config;
 
+import com.example.BarrierKU.common.annotation.CustomExceptionDescription;
+import com.example.BarrierKU.common.response.BaseResponse;
+import com.example.BarrierKU.common.response.ResponseCode;
+import com.example.BarrierKU.common.swagger.ExampleHolder;
+import com.example.BarrierKU.common.swagger.SwaggerResponseDescription;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.groupingBy;
 
 @OpenAPIDefinition(
         servers = @Server(url = "/", description = "default server url"),
@@ -26,6 +43,80 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI();
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+
+            CustomExceptionDescription customExceptionDescription = handlerMethod.getMethodAnnotation(
+                    CustomExceptionDescription.class);
+
+            // CustomExceptionDescription 어노테이션 단 메소드 적용
+            if (customExceptionDescription != null) {
+                generateErrorCodeResponseExample(operation, customExceptionDescription.value());
+            }
+
+            return operation;
+        };
+    }
+
+
+    private void generateErrorCodeResponseExample(
+            Operation operation, SwaggerResponseDescription type) {
+
+        ApiResponses responses = operation.getResponses();
+
+        Set<ResponseCode> responseCodeSet = type.getResponseCodeSet();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
+                responseCodeSet.stream()
+                        .map(
+                                responseCode -> {
+                                    return ExampleHolder.builder()
+                                            .holder(
+                                                    getSwaggerExample(responseCode))
+                                            .code(responseCode.getCode())
+                                            .name(responseCode.toString())
+                                            .build();
+                                }
+                        ).collect(groupingBy(ExampleHolder::getCode));
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+
+    private Example getSwaggerExample(ResponseCode responseCode) {
+        Map<String, Object> responseMap = new LinkedHashMap<>();
+        responseMap.put("isSuccess", responseCode.isSuccess());
+        responseMap.put("code", responseCode.getCode());
+        responseMap.put("message", responseCode.getMessage());
+        responseMap.put("result", null); // null 안전하게 허용됨
+
+        Example example = new Example();
+        example.description(responseCode.getMessage());
+        example.setValue(responseMap);
+
+        return example;
+    }
+
+
+    private void addExamplesToResponses(
+            ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, v) -> {
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+                    v.forEach(
+                            exampleHolder -> {
+                                mediaType.addExamples(
+                                        exampleHolder.getName(), exampleHolder.getHolder());
+                            });
+                    content.addMediaType("application/json", mediaType);
+                    apiResponse.setDescription("");
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(status.toString(), apiResponse);
+                });
     }
 
 }

--- a/src/main/java/com/example/BarrierKU/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/BarrierKU/common/config/SwaggerConfig.java
@@ -87,7 +87,7 @@ public class SwaggerConfig {
 
     private Example getSwaggerExample(ResponseCode responseCode) {
         Map<String, Object> responseMap = new LinkedHashMap<>();
-        responseMap.put("isSuccess", responseCode.isSuccess());
+        responseMap.put("success", responseCode.isSuccess());
         responseMap.put("code", responseCode.getCode());
         responseMap.put("message", responseCode.getMessage());
         responseMap.put("result", null); // null 안전하게 허용됨

--- a/src/main/java/com/example/BarrierKU/common/response/BaseResponse.java
+++ b/src/main/java/com/example/BarrierKU/common/response/BaseResponse.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
-@JsonPropertyOrder({"success", "code", "message", "data"})
+@JsonPropertyOrder({"success", "code", "message", "result"})
 public class BaseResponse<T> {
 
     @Schema(description = "성공 여부", example = "true")

--- a/src/main/java/com/example/BarrierKU/common/response/BaseResponse.java
+++ b/src/main/java/com/example/BarrierKU/common/response/BaseResponse.java
@@ -2,25 +2,34 @@ package com.example.BarrierKU.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@JsonPropertyOrder({"success", "code", "message", "data"})
 public class BaseResponse<T> {
-    @JsonProperty("isSuccess")
-    private final boolean isSuccess;
+
+    @Schema(description = "성공 여부", example = "true")
+    private final boolean success;
+
+    @Schema(description = "응답 코드", example = "200")
     private final int code;
+
+    @Schema(description = "응답 메세지", example = "요청에 성공하였습니다.")
     private final String message;
+
     private final T result;
 
     public BaseResponse(ResponseCode responseCode, T result) {
-        this.isSuccess = responseCode.isSuccess();
+        this.success = responseCode.isSuccess();
         this.code = responseCode.getCode();
         this.message = responseCode.getMessage();
         this.result = result;
     }
 
     public BaseResponse(ResponseCode responseCode) {
-        this.isSuccess = responseCode.isSuccess();
+        this.success = responseCode.isSuccess();
         this.code = responseCode.getCode();
         this.message = responseCode.getMessage();
         this.result = null;

--- a/src/main/java/com/example/BarrierKU/common/response/BaseResponse.java
+++ b/src/main/java/com/example/BarrierKU/common/response/BaseResponse.java
@@ -1,8 +1,8 @@
 package com.example.BarrierKU.common.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
-
 
 @Getter
 public class BaseResponse<T> {

--- a/src/main/java/com/example/BarrierKU/common/response/ResponseCode.java
+++ b/src/main/java/com/example/BarrierKU/common/response/ResponseCode.java
@@ -14,22 +14,32 @@ import lombok.NoArgsConstructor;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public enum ResponseCode {
 
-    // 1000 번대 : global 요청 성공/실패
+    // 테스트
+    TEST_EXCEPTION(true, 100, "테스트용 예외입니다."),
+
+    // global 요청 성공
     SUCCESS(true, 200, "요청에 성공하였습니다."),
+
+    // 공통 에러
     INVALID_PATH_VARIABLE_TYPE(false, 400, "요청 경로에 포함된 값의 타입이 올바르지 않습니다. 올바른 형식으로 요청해주세요."),
+    BAD_REQUEST(false, 400, "유효하지 않은 요청입니다."),
+    API_NOT_FOUND(false, 404, "존재하지 않는 API입니다."),
+    METHOD_NOT_ALLOWED(false, 405, "유효하지 않은 Http 메서드입니다."),
+    INTERNAL_SERVER_ERROR(false, 500, "서버 내부 오류입니다."),
 
-    // 2000 번대 : home
 
-    // 3000 번대 : building
+    // home
+
+    // building
     BUILDING_NOT_FOUND(false, 404, "해당 건물을 찾을 수 없습니다."),
 
-    // 4000 번대 : facility
+    // facility
     FACILITY_NOT_FOUND(false, 404, "해당 편의시설을 찾을 수 없습니다.");
 
-    // 5000 번대 : place
+    // place
 
 
-    // 6000 번대 : path
+    // path
 
     private boolean isSuccess;
     private int code;

--- a/src/main/java/com/example/BarrierKU/common/swagger/ExampleHolder.java
+++ b/src/main/java/com/example/BarrierKU/common/swagger/ExampleHolder.java
@@ -1,0 +1,2 @@
+package com.example.BarrierKU.common.swagger;public class ExampleHolder {
+}

--- a/src/main/java/com/example/BarrierKU/common/swagger/ExampleHolder.java
+++ b/src/main/java/com/example/BarrierKU/common/swagger/ExampleHolder.java
@@ -1,2 +1,14 @@
-package com.example.BarrierKU.common.swagger;public class ExampleHolder {
+package com.example.BarrierKU.common.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
 }

--- a/src/main/java/com/example/BarrierKU/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/example/BarrierKU/common/swagger/SwaggerResponseDescription.java
@@ -1,0 +1,2 @@
+package com.example.BarrierKU.common.annotation;public enum SwaggerResponseDescription {
+}

--- a/src/main/java/com/example/BarrierKU/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/example/BarrierKU/common/swagger/SwaggerResponseDescription.java
@@ -27,7 +27,6 @@ public enum SwaggerResponseDescription {
 
     SwaggerResponseDescription(Set<ResponseCode> responseCodeSet) {
         responseCodeSet.addAll(new LinkedHashSet<>(Set.of(
-                SUCCESS,
                 INVALID_PATH_VARIABLE_TYPE,
                 BAD_REQUEST,
                 API_NOT_FOUND,

--- a/src/main/java/com/example/BarrierKU/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/example/BarrierKU/common/swagger/SwaggerResponseDescription.java
@@ -1,2 +1,40 @@
-package com.example.BarrierKU.common.annotation;public enum SwaggerResponseDescription {
+package com.example.BarrierKU.common.swagger;
+
+import com.example.BarrierKU.common.response.ResponseCode;
+import lombok.Getter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static com.example.BarrierKU.common.response.ResponseCode.*;
+
+@Getter
+public enum SwaggerResponseDescription {
+
+    TEST(new LinkedHashSet<>(Set.of(
+            TEST_EXCEPTION
+    ))),
+
+    GET_BUILDING(new LinkedHashSet<>(Set.of(
+            BUILDING_NOT_FOUND
+    ))),
+
+    GET_FACILITY(new LinkedHashSet<>(Set.of(
+            FACILITY_NOT_FOUND
+    )));
+
+    private final Set<ResponseCode> responseCodeSet;
+
+    SwaggerResponseDescription(Set<ResponseCode> responseCodeSet) {
+        responseCodeSet.addAll(new LinkedHashSet<>(Set.of(
+                SUCCESS,
+                INVALID_PATH_VARIABLE_TYPE,
+                BAD_REQUEST,
+                API_NOT_FOUND,
+                METHOD_NOT_ALLOWED,
+                INTERNAL_SERVER_ERROR
+        )));
+
+        this.responseCodeSet = responseCodeSet;
+    }
 }

--- a/src/main/java/com/example/BarrierKU/controller/BuildingController.java
+++ b/src/main/java/com/example/BarrierKU/controller/BuildingController.java
@@ -1,10 +1,13 @@
 package com.example.BarrierKU.controller;
 
+import com.example.BarrierKU.common.annotation.CustomExceptionDescription;
 import com.example.BarrierKU.common.response.BaseResponse;
 import com.example.BarrierKU.dto.response.BuildingResponse;
 import com.example.BarrierKU.service.BuildingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import static com.example.BarrierKU.common.swagger.SwaggerResponseDescription.GET_BUILDING;
 
 @RestController
 @RequestMapping("/buildings")
@@ -13,6 +16,7 @@ public class BuildingController {
     private final BuildingService buildingService;
 
     @GetMapping("/{buildingId}")
+    @CustomExceptionDescription(GET_BUILDING)
     public BaseResponse<BuildingResponse> getBuilding(@PathVariable Long buildingId){
         BuildingResponse response = buildingService.findBuildingById(buildingId);
         return BaseResponse.ok(response);

--- a/src/main/java/com/example/BarrierKU/controller/TestController.java
+++ b/src/main/java/com/example/BarrierKU/controller/TestController.java
@@ -1,0 +1,2 @@
+package com.example.BarrierKU.controller;public class TestController {
+}

--- a/src/main/java/com/example/BarrierKU/controller/TestController.java
+++ b/src/main/java/com/example/BarrierKU/controller/TestController.java
@@ -1,2 +1,0 @@
-package com.example.BarrierKU.controller;public class TestController {
-}

--- a/src/main/java/com/example/BarrierKU/domain/facility/controller/FacilityController.java
+++ b/src/main/java/com/example/BarrierKU/domain/facility/controller/FacilityController.java
@@ -1,6 +1,8 @@
 package com.example.BarrierKU.domain.facility.controller;
 
+import com.example.BarrierKU.common.annotation.CustomExceptionDescription;
 import com.example.BarrierKU.common.response.BaseResponse;
+import com.example.BarrierKU.common.swagger.SwaggerResponseDescription;
 import com.example.BarrierKU.domain.facility.dto.FacilitiesResponse;
 import com.example.BarrierKU.domain.facility.service.FacilityService;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.example.BarrierKU.common.swagger.SwaggerResponseDescription.*;
+
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/facilities")
@@ -18,6 +22,7 @@ public class FacilityController {
     private final FacilityService facilityService;
 
     @GetMapping("/{facilityId}")
+    @CustomExceptionDescription(GET_FACILITY)
     public BaseResponse<FacilitiesResponse> getFacility(@PathVariable Long facilityId) {
         log.debug("[getFacility] 편의시설 조회, id = {}", facilityId);
         FacilitiesResponse response = facilityService.getFacility(facilityId);

--- a/src/main/java/com/example/BarrierKU/domain/test/controller/TestController.java
+++ b/src/main/java/com/example/BarrierKU/domain/test/controller/TestController.java
@@ -1,0 +1,28 @@
+package com.example.BarrierKU.controller;
+
+import com.example.BarrierKU.common.annotation.CustomExceptionDescription;
+import com.example.BarrierKU.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.example.BarrierKU.common.response.ResponseCode.*;
+import static com.example.BarrierKU.common.swagger.SwaggerResponseDescription.*;
+
+@Tag(name = "Test", description = "테스트 API")
+@RestController
+@RequestMapping("/test")
+public class TestController {
+
+    @Operation(
+            summary = "테스트 API",
+            description = "Swagger 공통 응답 및 예외 처리 테스트용 API"
+    )
+    @GetMapping
+    @CustomExceptionDescription(TEST)
+    public BaseResponse<String> testApi() {
+        return new BaseResponse<>(TEST_EXCEPTION);
+    }
+}

--- a/src/main/java/com/example/BarrierKU/domain/test/controller/TestController.java
+++ b/src/main/java/com/example/BarrierKU/domain/test/controller/TestController.java
@@ -2,6 +2,7 @@ package com.example.BarrierKU.domain.test.controller;
 
 import com.example.BarrierKU.common.annotation.CustomExceptionDescription;
 import com.example.BarrierKU.common.response.BaseResponse;
+import com.example.BarrierKU.domain.test.dto.response.TestResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +23,7 @@ public class TestController {
     )
     @GetMapping
     @CustomExceptionDescription(TEST)
-    public BaseResponse<String> testApi() {
-        return new BaseResponse<>(TEST_EXCEPTION);
+    public BaseResponse<TestResponseDTO> testApi() {
+        return BaseResponse.ok(new TestResponseDTO("테스트 예시 응답"));
     }
 }

--- a/src/main/java/com/example/BarrierKU/domain/test/controller/TestController.java
+++ b/src/main/java/com/example/BarrierKU/domain/test/controller/TestController.java
@@ -1,4 +1,4 @@
-package com.example.BarrierKU.controller;
+package com.example.BarrierKU.domain.test.controller;
 
 import com.example.BarrierKU.common.annotation.CustomExceptionDescription;
 import com.example.BarrierKU.common.response.BaseResponse;

--- a/src/main/java/com/example/BarrierKU/domain/test/dto/response/TestResponseDTO.java
+++ b/src/main/java/com/example/BarrierKU/domain/test/dto/response/TestResponseDTO.java
@@ -1,0 +1,7 @@
+package com.example.BarrierKU.domain.test.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TestResponseDTO(
+        @Schema(description = "테스트 응답 메세지", example = "테스트 성공 응답 예시") String message) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,16 +1,98 @@
 spring:
+  application:
+    name: ku-barrier-free
+  profiles:
+    group:
+      local : local-db, dev-port, common
+      dev: dev-db, dev-port, common
+      prod: prod-db, prod-port, common
+    active: local
+  web:
+    resources:
+      add-mappings: false
+---
+# 로컬에서 사용하는 DB
+spring:
+  config:
+    activate:
+      on-profile: local-db
   datasource:
-    driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:testdb
     username: sa
     password:
+    driver-class-name: org.h2.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
-        show_sql: true
         format_sql: true
-      logging.level:
-        org.hibernate.SQL: debug
-        
+        show_sql: true
+        highlight_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+---
+# 개발용 DB
+spring:
+  config:
+    activate:
+      on-profile: dev-db
+  datasource:
+    url: ${DEV_DATASOURCE_URL}
+    username: ${DEV_DATASOURCE_USERNAME}
+    password: ${DEV_DATASOURCE_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        highlight_sql: true
+    database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG95Dialect
+---
+# 배포용 DB
+spring:
+  config:
+    activate:
+      on-profile: prod-db
+  datasource:
+    url: ${PROD_DATASOURCE_URL}
+    username: ${PROD_DATASOURCE_USERNAME}
+    password: ${PROD_DATASOURCE_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        highlight_sql: true
+    database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG95Dialect
+---
+# 개발용 포트
+spring:
+  config:
+    activate:
+      on-profile: dev-port
+server:
+  port: 9001
+---
+# 배포용 포트
+spring:
+  config:
+    activate:
+      on-profile: prod-port
+server:
+  port: 9002
+---
+# 공통 속성
+spring:
+  config:
+    activate:
+      on-profile: common
+logging:
+  level:
+    root: info
+


### PR DESCRIPTION
## Related issue 🛠
- closed #11 

## Work Description 📝
- Swagger 를 좀 더 제대로 사용할 수 있도록 구현을 추가하였습니다.
- application.yml 파일 하나에서 프로필을 분리하여 사용할 수 있도록 하였습니다.


### Swagger 예외 명세 방식

**1. ResponseCode 에 필요한 예외를 추가합니다.**
<img width="550" alt="스크린샷 2025-07-09 오후 5 40 35" src="https://github.com/user-attachments/assets/ba579bef-b888-468e-8f74-0edb0b3385da" />


**2. SwaggerResponseDescription 에, 각각의 API 마다 어떠한 예외들이 발생할 가능성이 있는지 확인 후 Set을 만들어줍니다.**

SUCCESS, BAD_REQUEST, API_NOT_FOUND, METHOD_NOT_ALLOWED, INTERNAL_SERVER_ERROR 같은 경우 기본적으로 각 API 마다 발생할 가능성이 있다고 가정하기 때문에 별도로 추가하지 않아도 자동으로 추가됩니다.

따라서 첨부한 사진과 같이 TEST_EXCEPTION 처럼, 해당 API 에 대해 발생할 수 있는, 공통 예외 이외의 것들을 포함하는 Set을 만들어주시면 됩니다.
<img width="550" alt="스크린샷 2025-07-09 오후 5 41 33" src="https://github.com/user-attachments/assets/61ed4b99-1305-4012-9cd5-87ada6fd5224" />



**3. 그 후 생성한 API에 CustomExceptionDescription 어노테이션을 붙여주며, 괄호 안에 위에서 만들어준 SwaggerResponseDescription 값만 집어넣어주시면 알아서 Swagger 에 해당 예외들을 보여주게 됩니다.**
<img width="577" alt="스크린샷 2025-07-09 오후 5 42 16" src="https://github.com/user-attachments/assets/c7cebc58-ed5c-45ae-a43d-76ee5d49f347" />


### application.yml 형태
<img width="550" alt="스크린샷 2025-07-09 오후 5 44 41" src="https://github.com/user-attachments/assets/cf1f161f-748d-494a-ab04-5ef02cdff588" />
<img width="550" alt="스크린샷 2025-07-09 오후 5 44 55" src="https://github.com/user-attachments/assets/e398d101-ea7e-4e27-a71c-fa258a882e0b" />


1. 하나의 application.yml 파일 내에서 local, dev, prod 프로필을 분리하여 사용하고자 지금과 같이 구현하였습니다.
2. local, dev 의 경우 서버 포트는 9001 번을 사용하도록 하였습니다. 반면에 prod 프로필의 경우 9002 번 포트를 사용합니다.
3. local db의 경우 추후 길 찾기 기능이 추가 되기 전까지는 현재와 같이 h2 를 사용할 수 있도록 메모리 기반 h2 DB 를 사용할 수 있도록 하였고, 추후 배포된 후 사용될 개발, 배포용 프로필에서는 postgresql DB를 사용할 수 있도록 미리 세팅해두었습니다. 실제로 dev, prod 프로필을 가지고 로컬에서 사용하지만 않는다면 에러는 터지지 않습니다.



## Screenshot 📸

<img width="550" alt="스크린샷 2025-07-09 오후 5 43 12" src="https://github.com/user-attachments/assets/35509bf9-3a77-49ec-937d-3cf31e3b244c" />

<img width="550" alt="스크린샷 2025-07-09 오후 5 42 53" src="https://github.com/user-attachments/assets/b39fdca6-eed1-41ac-91da-23d6230960be" />

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢
혹시 사용 방법이 다소 헷갈리신다면 언제든 연락주세요