### PR TITLE
[Feat] 교외 특이사항 조회 구현

### DIFF
--- a/src/main/java/com/example/BarrierKU/common/response/ResponseCode.java
+++ b/src/main/java/com/example/BarrierKU/common/response/ResponseCode.java
@@ -29,6 +29,7 @@ public enum ResponseCode {
 
 
     // home
+    OUTSIDE_SIGNIFICANT_NOT_FOUND(false, 404, "해당 교외 특이사항을 찾을 수 없습니다."),
 
     // building
     BUILDING_NOT_FOUND(false, 404, "해당 건물을 찾을 수 없습니다."),

--- a/src/main/java/com/example/BarrierKU/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/example/BarrierKU/common/swagger/SwaggerResponseDescription.java
@@ -27,6 +27,10 @@ public enum SwaggerResponseDescription {
             SPACE_NOT_FOUND
     ))),
 
+    GET_OUTSIDE_SIGNIFICANT_INFO(new LinkedHashSet<>(Set.of(
+            OUTSIDE_SIGNIFICANT_NOT_FOUND
+    ))),
+
     DEFAULT(new LinkedHashSet<>());
 
     private final Set<ResponseCode> responseCodeSet;

--- a/src/main/java/com/example/BarrierKU/domain/home/controller/HomeController.java
+++ b/src/main/java/com/example/BarrierKU/domain/home/controller/HomeController.java
@@ -3,15 +3,18 @@ package com.example.BarrierKU.domain.home.controller;
 import com.example.BarrierKU.common.annotation.CustomExceptionDescription;
 import com.example.BarrierKU.common.response.BaseResponse;
 import com.example.BarrierKU.domain.home.dto.HomeResponse;
+import com.example.BarrierKU.domain.home.dto.OutsideSignificantResponse;
 import com.example.BarrierKU.domain.home.service.HomeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.example.BarrierKU.common.swagger.SwaggerResponseDescription.DEFAULT;
+import static com.example.BarrierKU.common.swagger.SwaggerResponseDescription.GET_OUTSIDE_SIGNIFICANT_INFO;
 
 @Tag(name = "Home", description = "Home API")
 @RequiredArgsConstructor
@@ -29,5 +32,15 @@ public class HomeController {
     @CustomExceptionDescription(DEFAULT)
     public BaseResponse<HomeResponse> getHomeInfo() {
         return BaseResponse.ok(homeService.getHomeInfo());
+    }
+
+    @Operation(
+            summary = "교외 특이사항 조회 API",
+            description = "교외 특이사항의 정보를 보여주는 API 입니다."
+    )
+    @GetMapping("/outside-significants/{outsideSignificantId}")
+    @CustomExceptionDescription(GET_OUTSIDE_SIGNIFICANT_INFO)
+    public BaseResponse<OutsideSignificantResponse> getOutsideSignificantInfo(@PathVariable("outsideSignificantId") Long outsideSignificantId) {
+        return BaseResponse.ok(homeService.getOutsideSignificantInfo(outsideSignificantId));
     }
 }

--- a/src/main/java/com/example/BarrierKU/domain/home/dto/OutdoorSignificantResponse.java
+++ b/src/main/java/com/example/BarrierKU/domain/home/dto/OutdoorSignificantResponse.java
@@ -1,0 +1,15 @@
+package com.example.BarrierKU.domain.home.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record OutdoorSignificantResponse(
+        @Schema(description = "교외 특이사항 이미지", example = "http://image1.png")
+        String imageUrl,
+        @Schema(description = "교외 특이사항", example = "사진 기준 왼쪽에 경사로가 있어서 장애 학우들도 이용 가능합니다.")
+        String description,
+        @Schema(description = "위도", example = "37.123123")
+        double latitude,
+        @Schema(description = "경도", example = "127.123123")
+        double longitude
+) {
+}

--- a/src/main/java/com/example/BarrierKU/domain/home/dto/OutsideSignificantResponse.java
+++ b/src/main/java/com/example/BarrierKU/domain/home/dto/OutsideSignificantResponse.java
@@ -2,7 +2,7 @@ package com.example.BarrierKU.domain.home.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record OutdoorSignificantResponse(
+public record OutsideSignificantResponse(
         @Schema(description = "교외 특이사항 이미지", example = "http://image1.png")
         String imageUrl,
         @Schema(description = "교외 특이사항", example = "사진 기준 왼쪽에 경사로가 있어서 장애 학우들도 이용 가능합니다.")

--- a/src/main/java/com/example/BarrierKU/domain/home/dto/OutsideSignificantResponse.java
+++ b/src/main/java/com/example/BarrierKU/domain/home/dto/OutsideSignificantResponse.java
@@ -2,9 +2,11 @@ package com.example.BarrierKU.domain.home.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 public record OutsideSignificantResponse(
-        @Schema(description = "교외 특이사항 이미지", example = "http://image1.png")
-        String imageUrl,
+        @Schema(description = "교외 특이사항 이미지", example = "[\"http://image1.png\", \"http://image2.png\"]")
+        List<String> imageUrls,
         @Schema(description = "교외 특이사항", example = "사진 기준 왼쪽에 경사로가 있어서 장애 학우들도 이용 가능합니다.")
         String description,
         @Schema(description = "위도", example = "37.123123")
@@ -12,4 +14,7 @@ public record OutsideSignificantResponse(
         @Schema(description = "경도", example = "127.123123")
         double longitude
 ) {
+        public static OutsideSignificantResponse of(List<String> imageUrls, String description, double latitude, double longitude) {
+                return new OutsideSignificantResponse(imageUrls, description, latitude, longitude);
+        }
 }

--- a/src/main/java/com/example/BarrierKU/domain/home/repository/OutsideSignificantRepository.java
+++ b/src/main/java/com/example/BarrierKU/domain/home/repository/OutsideSignificantRepository.java
@@ -2,6 +2,13 @@ package com.example.BarrierKU.domain.home.repository;
 
 import com.example.BarrierKU.domain.outdoor.OutsideSignificant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface OutsideSignificantRepository extends JpaRepository<OutsideSignificant, Long> {
+
+    @Query("select os from OutsideSignificant os left join fetch os.outsideSignificantImages where os.id = :outsideSignificantId")
+    Optional<OutsideSignificant> findOutsideSignificantWithImages(@Param("outsideSignificantId") Long outsideSignificantId);
 }

--- a/src/main/java/com/example/BarrierKU/domain/home/service/HomeService.java
+++ b/src/main/java/com/example/BarrierKU/domain/home/service/HomeService.java
@@ -1,21 +1,29 @@
 package com.example.BarrierKU.domain.home.service;
 
+import com.example.BarrierKU.common.exception.BarrierKuException;
+import com.example.BarrierKU.common.response.ResponseCode;
 import com.example.BarrierKU.domain.building.repository.BuildingRepository;
 import com.example.BarrierKU.domain.home.dto.HomeItem;
 import com.example.BarrierKU.domain.home.dto.HomeResponse;
+import com.example.BarrierKU.domain.home.dto.OutsideSignificantResponse;
 import com.example.BarrierKU.domain.home.repository.ObstacleRepository;
 import com.example.BarrierKU.domain.home.repository.OutsideSignificantRepository;
+import com.example.BarrierKU.domain.image.OutsideSignificantImage;
 import com.example.BarrierKU.domain.outdoor.Obstacle;
+import com.example.BarrierKU.domain.outdoor.OutsideSignificant;
 import com.example.BarrierKU.domain.type.ObstacleType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.example.BarrierKU.common.response.ResponseCode.*;
 import static com.example.BarrierKU.domain.type.ObstacleType.*;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class HomeService {
 
     private final BuildingRepository buildingRepository;
@@ -46,6 +54,16 @@ public class HomeService {
         return HomeResponse.of(buildings, significants, curbs, ramps, stairs);
     }
 
+    public OutsideSignificantResponse getOutsideSignificantInfo(Long outsideSignificantId) {
+        OutsideSignificant outsideSignificant = outsideSignificantRepository.findOutsideSignificantWithImages(outsideSignificantId)
+                .orElseThrow(() -> new BarrierKuException(OUTSIDE_SIGNIFICANT_NOT_FOUND));
+
+        return OutsideSignificantResponse.of(
+                outsideSignificant.getOutsideSignificantImages().stream().map(OutsideSignificantImage::getUrl).toList(),
+                outsideSignificant.getDescription(),
+                outsideSignificant.getSpot().getY(),
+                outsideSignificant.getSpot().getX());
+    }
 
     private List<HomeItem> getHomeItemWithObstacleType(List<Obstacle> obstacleList, ObstacleType type) {
         return obstacleList.stream()

--- a/src/main/java/com/example/BarrierKU/domain/outdoor/OutsideSignificant.java
+++ b/src/main/java/com/example/BarrierKU/domain/outdoor/OutsideSignificant.java
@@ -2,8 +2,7 @@ package com.example.BarrierKU.domain.outdoor;
 
 import com.example.BarrierKU.domain.image.OutsideSignificantImage;
 import jakarta.persistence.*;
-import lombok.Generated;
-import lombok.Getter;
+import lombok.*;
 import org.locationtech.jts.geom.Point;
 
 import java.util.ArrayList;
@@ -13,7 +12,7 @@ import java.util.List;
 @Getter
 public class OutsideSignificant {
 
-    @Id @Generated
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "outside_significant_id")
     private Long id;
 


### PR DESCRIPTION
## Related issue 🛠
- closed #21 

## Work Description 📝
- 교외 특이사항 조회 API 를 구현하였습니다.
- 교외 특이사항을 조회할 때 교외 특이사항 이미지까지 한 번에 끌어오도록 fetch join 을 활용하였습니다 -> 1 + 1 쿼리 -> 1 번의 쿼리로 개선
- OutsideSignificant 의 id 생성 정책이 잘못 설정되어있길래 @GeneratedValue(strategy = GenerationType.IDENTITY) 로 수정하였습니다.

## Screenshot 📸
<img width="546" height="257" alt="스크린샷 2025-07-22 오후 9 38 56" src="https://github.com/user-attachments/assets/21a705b3-20ce-49c9-8b30-d5db732ba9de" />

## Uncompleted Tasks 😅

## To Reviewers 📢
