### PR TITLE
[Feat] 건물 상세 조회 시 전층 정보 반환

### DIFF
--- a/src/main/java/com/example/BarrierKU/domain/building/dto/BuildingResponse.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/dto/BuildingResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -57,6 +58,7 @@ public class BuildingResponse {
                     "}]"
     )
     private List<SignificantInfo> significantInfos;
+    private Map<String, FloorResponse> floorMap;
 
     @Getter
     @AllArgsConstructor
@@ -91,7 +93,7 @@ public class BuildingResponse {
         }
     }
 
-    public BuildingResponse(Long buildingId, int number, String name, String department, String image, Set<String> purposes, List<Door> doors, List<Significant> significants) {
+    public BuildingResponse(Long buildingId, int number, String name, String department, String image, Set<String> purposes, List<Door> doors, List<Significant> significants, Map<String, FloorResponse> floorMap) {
         this.id = buildingId;
         this.number = number;
         this.name = name;
@@ -100,5 +102,6 @@ public class BuildingResponse {
         this.facilityPurposes = purposes;
         this.doorInfos = doors.stream().map(door -> new DoorInfo(door)).toList();
         this.significantInfos = significants.stream().map(significant -> new SignificantInfo(significant)).toList();
+        this.floorMap = floorMap;
     }
 }

--- a/src/main/java/com/example/BarrierKU/domain/building/dto/BuildingResponse.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/dto/BuildingResponse.java
@@ -84,6 +84,10 @@ public class BuildingResponse {
                     "}"
     )
     private Map<String, FloorResponse> floorMap;
+    @Schema(description = "위도", example = "37.54321")
+    private double latitude;
+    @Schema(description = "경도", example = "127.11111")
+    private double longitude;
 
     @Getter
     @AllArgsConstructor
@@ -118,12 +122,14 @@ public class BuildingResponse {
         }
     }
 
-    public BuildingResponse(Long buildingId, int number, String name, String department, String image, Set<String> purposes, List<Door> doors, List<Significant> significants, Map<String, FloorResponse> floorMap) {
+    public BuildingResponse(Long buildingId, int number, String name, String department, String image, double latitude, double longitude, Set<String> purposes, List<Door> doors, List<Significant> significants, Map<String, FloorResponse> floorMap) {
         this.id = buildingId;
         this.number = number;
         this.name = name;
         this.department = department;
         this.image = image;
+        this.latitude = latitude;
+        this.longitude = longitude;
         this.facilityPurposes = purposes;
         this.doorInfos = doors.stream().map(door -> new DoorInfo(door)).toList();
         this.significantInfos = significants.stream().map(significant -> new SignificantInfo(significant)).toList();

--- a/src/main/java/com/example/BarrierKU/domain/building/dto/BuildingResponse.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/dto/BuildingResponse.java
@@ -27,7 +27,7 @@ public class BuildingResponse {
     private String name;
     @Schema(description = "건물 담당 부서", example = "경영(전문)대학원, 경영대학")
     private String department;
-    @Schema(description = "도면 이미지", example = "image.png")
+    @Schema(description = "건물 이미지", example = "image.png")
     private String image;
     @Schema(
             description = "문 정보 리스트",

--- a/src/main/java/com/example/BarrierKU/domain/building/dto/BuildingResponse.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/dto/BuildingResponse.java
@@ -31,16 +31,22 @@ public class BuildingResponse {
     private String image;
     @Schema(
             description = "문 정보 리스트",
-            example = "[{" +
+            example = "[" +
+                    "{" +
                     "\"id\": 1," +
                     "\"wheelchair\": true," +
-                    "\"imageUrl\": [\"https://example.com/door1.jpg\", \"https://example.com/door2.jpg\"]" +
-                    "}, {" +
+                    "\"imageUrl\": [\"https://example.com/door1.jpg\", \"https://example.com/door2.jpg\"]," +
+                    "\"latitude\": 37.12345," +
+                    "\"longitude\": 127.98765" +
+                    "}," +
+                    "{" +
                     "\"id\": 2," +
                     "\"wheelchair\": false," +
-                    "\"imageUrl\": [\"https://example.com/door3.jpg\"]" +
-                    "\"spot\": [\"https://example.com/door3.jpg\"]" +
-                    "}]"
+                    "\"imageUrl\": [\"https://example.com/door3.jpg\"]," +
+                    "\"latitude\": 37.54321," +
+                    "\"longitude\": 127.11111" +
+                    "}" +
+                    "]"
     )
     private List<DoorInfo> doorInfos;
     @Schema(description = "해당 건물에 존재하는 편의시설 종류", example = "[\"은행\", \"휴게실\", \"카페\"]")
@@ -58,6 +64,25 @@ public class BuildingResponse {
                     "}]"
     )
     private List<SignificantInfo> significantInfos;
+    @Schema(
+            description = "층별 공간 정보 (key: 층 이름 예: 1, B1)",
+            example = "{" +
+                    "\"B1\": {" +
+                    "\"drawings\": [\"image.png\"]," +
+                    "\"purposes\": [\"은행\", \"휴게실\", \"카페\"]," +
+                    "\"spaceSummaries\": [" +
+                    "{" +
+                    "\"id\": 1," +
+                    "\"roomNumber\": \"104-1호\"," +
+                    "\"roomName\": \"강의실\"," +
+                    "\"comment\": \"원형책상\"," +
+                    "\"roomImages\": [\"https://example.com/image1.jpg\"]," +
+                    "\"isLecture\": true" +
+                    "}" +
+                    "]" +
+                    "}" +
+                    "}"
+    )
     private Map<String, FloorResponse> floorMap;
 
     @Getter

--- a/src/main/java/com/example/BarrierKU/domain/building/dto/SpaceSummary.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/dto/SpaceSummary.java
@@ -9,9 +9,13 @@ public record SpaceSummary(
         Long id,
         @Schema(description = "호수")
         String roomNumber,
+        @Schema(description = "호실명")
         String roomName,
+        @Schema(description = "특이사항")
         String comment,
+        @Schema(description = "방 이미지 url")
         List<String> roomImages,
+        @Schema(description = "강의여부")
         boolean isLecture
 ) {
 }

--- a/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
@@ -40,7 +40,8 @@ public class BuildingService {
         Map<String, List<Room>> roomsByFloor = groupedByFloor(building);
         Map<String, FloorResponse> floorMap = getFloorResponseMap(roomsByFloor, building);
         return new BuildingResponse(id, building.getNumber(), building.getName(),
-                building.getDepartment(), building.getImage(), purposes, doors, significants, floorMap);
+                building.getDepartment(), building.getImage(), building.getSpot().getY(), building.getSpot().getX(),
+                purposes, doors, significants, floorMap);
     }
 
     public FloorResponse getFloorInfo(Long id, String targetFloor) {

--- a/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
@@ -61,10 +61,6 @@ public class BuildingService {
                 .orElseThrow(() -> new BarrierKuException(BUILDING_NOT_FOUND));
     }
 
-    private Set<String> getPurposes(Building building) {
-        return building.getFacilityPurposes().stream().map(Purpose::getValue).collect(Collectors.toSet());
-    }
-
     private Map<String, FloorResponse> getFloorResponseMap(Map<String, List<Room>> roomsByFloor, Building building) {
         return roomsByFloor.entrySet().stream().collect(Collectors.toMap(
                 Map.Entry::getKey,
@@ -88,17 +84,21 @@ public class BuildingService {
                         , room.isLecture())).toList();
     }
 
+    private List<String> getDrawings(String targetFloor, Building building) {
+        return building.getDrawings().stream()
+                .filter(drawing -> drawing.getFloor().equals(targetFloor))
+                .map(drawing -> drawing.getImage())
+                .toList();
+    }
+
     private Set<String> getPurposes(String targetFloor, Building building) {
         return building.getFacilities().stream()
                 .filter(facility -> facility.getFloor().equals(targetFloor))
                 .map(facility -> facility.getPurpose().getValue()).collect(Collectors.toSet());
     }
 
-    private List<String> getDrawings(String targetFloor, Building building) {
-        return building.getDrawings().stream()
-                .filter(drawing -> drawing.getFloor().equals(targetFloor))
-                .map(drawing -> drawing.getImage())
-                .toList();
+    private Set<String> getPurposes(Building building) {
+        return building.getFacilityPurposes().stream().map(Purpose::getValue).collect(Collectors.toSet());
     }
 
     private Map<String, List<Room>> groupedByFloor(Building building) {

--- a/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
@@ -32,13 +32,37 @@ public class BuildingService {
 
     public BuildingResponse findBuildingById(Long id) {
         Building building = getBuilding(id);
-        Set<String> purposes = building.getFacilityPurposes().stream().map(Purpose::getValue).collect(Collectors.toSet());
+        Set<String> purposes = getPurposes(building);
         List<Door> doors = building.getDoors();
         List<Significant> significants = building.getSignificants();
         Map<String, List<Room>> roomsByFloor = groupedByFloor(building);
         Map<String, FloorResponse> floorMap = getFloorResponseMap(roomsByFloor, building);
-        return new BuildingResponse(id,building.getNumber(),building.getName(), building.getDepartment(),building.getImage(),
-                purposes, doors, significants, floorMap);
+        return new BuildingResponse(id, building.getNumber(), building.getName(),
+                building.getDepartment(), building.getImage(), purposes, doors, significants, floorMap);
+    }
+
+    public FloorResponse getFloorInfo(Long id, String targetFloor) {
+        Building building = getBuilding(id);
+        List<String> drawings = getDrawings(targetFloor, building);
+        Set<String> purposes = getPurposes(targetFloor, building);
+        List<SpaceSummary> spaceSummaries = getSpaceSummaries(targetFloor, building);
+
+        return new FloorResponse(drawings, purposes, spaceSummaries);
+    }
+
+    public SpaceResponse getSpaceInfo(Long buildingId, Long spaceId, int type) {
+        Room room = roomRepository.findByIdAndBuildingId(spaceId, buildingId)
+                .orElseThrow(() -> new BarrierKuException(SPACE_NOT_FOUND));
+        return SpaceResponse.of(room, type);
+    }
+
+    public Building getBuilding(Long id) {
+        return buildingRepository.findById(id)
+                .orElseThrow(() -> new BarrierKuException(BUILDING_NOT_FOUND));
+    }
+
+    private Set<String> getPurposes(Building building) {
+        return building.getFacilityPurposes().stream().map(Purpose::getValue).collect(Collectors.toSet());
     }
 
     private Map<String, FloorResponse> getFloorResponseMap(Map<String, List<Room>> roomsByFloor, Building building) {
@@ -55,15 +79,6 @@ public class BuildingService {
                     return new FloorResponse(drawings, purposesFloor, summaries);
                 }
         ));
-    }
-
-    public FloorResponse getFloorInfo(Long id, String targetFloor) {
-        Building building = getBuilding(id);
-        List<String> drawings = getDrawings(targetFloor, building);
-        Set<String> purposes = getPurposes(targetFloor, building);
-        List<SpaceSummary> spaceSummaries = getSpaceSummaries(targetFloor, building);
-
-        return new FloorResponse(drawings, purposes, spaceSummaries);
     }
 
     private List<SpaceSummary> getSpaceSummaries(String targetFloor, Building building) {
@@ -86,18 +101,7 @@ public class BuildingService {
                 .toList();
     }
 
-    public Building getBuilding(Long id) {
-        return buildingRepository.findById(id)
-                .orElseThrow(() -> new BarrierKuException(BUILDING_NOT_FOUND));
-    }
-
-    public SpaceResponse getSpaceInfo(Long buildingId, Long spaceId, int type) {
-        Room room = roomRepository.findByIdAndBuildingId(spaceId, buildingId)
-                .orElseThrow(() -> new BarrierKuException(SPACE_NOT_FOUND));
-        return SpaceResponse.of(room, type);
-    }
-
-    private Map<String, List<Room>> groupedByFloor(Building building){
+    private Map<String, List<Room>> groupedByFloor(Building building) {
         return building.getRooms().stream().collect(Collectors.groupingBy(Room::getFloor));
     }
 }

--- a/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
@@ -32,8 +32,7 @@ public class BuildingService {
 
     public BuildingResponse findBuildingById(Long id) {
         Building building = getBuilding(id);
-        Set<String> purposes = building.getFacilities().stream()
-                .map(facility -> facility.getPurpose().getValue()).collect(Collectors.toSet());
+        Set<String> purposes = building.getFacilityPurposes().stream().map(Purpose::getValue).collect(Collectors.toSet());
         List<Door> doors = building.getDoors();
         List<Significant> significants = building.getSignificants();
         Map<String, List<Room>> roomsByFloor = groupedByFloor(building);
@@ -70,8 +69,8 @@ public class BuildingService {
     private List<SpaceSummary> getSpaceSummaries(String targetFloor, Building building) {
         return building.getRooms().stream().filter(room -> room.getFloor().equals(targetFloor))
                 .map(room -> new SpaceSummary(room.getId(), room.getRoomNumber(), room.getRoomName()
-                        , room.getRoomComment(), room.getRoomImages().stream().map(RoomImage::getUrl).collect(Collectors.toList())
-                        , room.isLecture())).collect(Collectors.toList());
+                        , room.getRoomComment(), room.getRoomImages().stream().map(RoomImage::getUrl).toList()
+                        , room.isLecture())).toList();
     }
 
     private Set<String> getPurposes(String targetFloor, Building building) {

--- a/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
@@ -15,6 +15,7 @@ import com.example.BarrierKU.domain.indoor.Significant;
 import com.example.BarrierKU.domain.type.Purpose;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ import static com.example.BarrierKU.common.response.ResponseCode.SPACE_NOT_FOUND
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class BuildingService {
     private final BuildingRepository buildingRepository;
     private final RoomRepository roomRepository;

--- a/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
@@ -56,7 +56,7 @@ public class BuildingService {
         return SpaceResponse.of(room, type);
     }
 
-    public Building getBuilding(Long id) {
+    private Building getBuilding(Long id) {
         return buildingRepository.findById(id)
                 .orElseThrow(() -> new BarrierKuException(BUILDING_NOT_FOUND));
     }

--- a/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
+++ b/src/main/java/com/example/BarrierKU/domain/building/service/BuildingService.java
@@ -12,10 +12,12 @@ import com.example.BarrierKU.domain.building.repository.BuildingRepository;
 import com.example.BarrierKU.domain.indoor.Door;
 import com.example.BarrierKU.domain.indoor.Room;
 import com.example.BarrierKU.domain.indoor.Significant;
+import com.example.BarrierKU.domain.type.Purpose;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -34,8 +36,26 @@ public class BuildingService {
                 .map(facility -> facility.getPurpose().getValue()).collect(Collectors.toSet());
         List<Door> doors = building.getDoors();
         List<Significant> significants = building.getSignificants();
+        Map<String, List<Room>> roomsByFloor = groupedByFloor(building);
+        Map<String, FloorResponse> floorMap = getFloorResponseMap(roomsByFloor, building);
         return new BuildingResponse(id,building.getNumber(),building.getName(), building.getDepartment(),building.getImage(),
-                purposes, doors, significants);
+                purposes, doors, significants, floorMap);
+    }
+
+    private Map<String, FloorResponse> getFloorResponseMap(Map<String, List<Room>> roomsByFloor, Building building) {
+        return roomsByFloor.entrySet().stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> {
+                    String floor = entry.getKey();
+                    List<Room> rooms = entry.getValue();
+
+                    List<String> drawings = getDrawings(floor, building);
+                    Set<String> purposesFloor = getPurposes(floor, building);
+                    List<SpaceSummary> summaries = getSpaceSummaries(floor, building);
+
+                    return new FloorResponse(drawings, purposesFloor, summaries);
+                }
+        ));
     }
 
     public FloorResponse getFloorInfo(Long id, String targetFloor) {
@@ -76,5 +96,9 @@ public class BuildingService {
         Room room = roomRepository.findByIdAndBuildingId(spaceId, buildingId)
                 .orElseThrow(() -> new BarrierKuException(SPACE_NOT_FOUND));
         return SpaceResponse.of(room, type);
+    }
+
+    private Map<String, List<Room>> groupedByFloor(Building building){
+        return building.getRooms().stream().collect(Collectors.groupingBy(Room::getFloor));
     }
 }

--- a/src/main/java/com/example/BarrierKU/domain/image/DoorImage.java
+++ b/src/main/java/com/example/BarrierKU/domain/image/DoorImage.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 public class DoorImage {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "door_image_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/image/Drawing.java
+++ b/src/main/java/com/example/BarrierKU/domain/image/Drawing.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public class Drawing {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "floor_drawing_id")
     private long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/image/Image.java
+++ b/src/main/java/com/example/BarrierKU/domain/image/Image.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 @Getter
 public class Image {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "image_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/image/OutsideSignificantImage.java
+++ b/src/main/java/com/example/BarrierKU/domain/image/OutsideSignificantImage.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Getter
 public class OutsideSignificantImage {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "outside_siginificant_image_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/image/RoomImage.java
+++ b/src/main/java/com/example/BarrierKU/domain/image/RoomImage.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Getter
 public class RoomImage {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "room_image_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/image/SignificantImage.java
+++ b/src/main/java/com/example/BarrierKU/domain/image/SignificantImage.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Getter
 public class SignificantImage {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "significant_image_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/indoor/Building.java
+++ b/src/main/java/com/example/BarrierKU/domain/indoor/Building.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 
 public class Building {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "building_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/indoor/Door.java
+++ b/src/main/java/com/example/BarrierKU/domain/indoor/Door.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Getter
 public class Door {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "door_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/indoor/Facilities.java
+++ b/src/main/java/com/example/BarrierKU/domain/indoor/Facilities.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Facilities {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "facilities_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/indoor/Room.java
+++ b/src/main/java/com/example/BarrierKU/domain/indoor/Room.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class Room {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "room_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/indoor/RoomInfo.java
+++ b/src/main/java/com/example/BarrierKU/domain/indoor/RoomInfo.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public class RoomInfo {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "room_info_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/indoor/Significant.java
+++ b/src/main/java/com/example/BarrierKU/domain/indoor/Significant.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 @Getter
 public class Significant {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "significant_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/outdoor/Obstacle.java
+++ b/src/main/java/com/example/BarrierKU/domain/outdoor/Obstacle.java
@@ -9,7 +9,7 @@ import org.locationtech.jts.geom.Point;
 @Getter
 public class Obstacle {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "obstacle_id")
     private Long id;
 

--- a/src/main/java/com/example/BarrierKU/domain/outdoor/OutsideSignificant.java
+++ b/src/main/java/com/example/BarrierKU/domain/outdoor/OutsideSignificant.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Getter
 public class OutsideSignificant {
 
-    @Id @Generated
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "outside_significant_id")
     private Long id;
 


### PR DESCRIPTION
## Related issue 🛠
- closed #24

## Work Description 📝
- 아래의 요구사항에 부합하도록, BuildingResponse 안에 FloorResponse들을 넣었습니다. 
- 각 건물의 호실들을 받아와서 이를 층별로 그룹핑 하여 Map<String, List<Room>> 를 만든 후 이를 기반으로 Map<String, FloorResponse> 를 생성하였습니다. 
- 그냥 처음부터 Drawings를 기반으로  바로 맵 하나만 만들지 왜 그랬냐, 라고 여쭤보신다면, 어차피 층과 도면이 일대다 여서 도면이었어도 그룹핑을 했어야했고, 도면이 없는 층도 있다고 알고 있어서 호실들을 쫙 가져온 다음에 층별로 매핑하였습니다.
- 그 외에도 메서드 순서가 자바 컨벤션에 맞지 않아서 일부 수정했고, 이전 pr에서 말씀해주신 Schema도 추가하였습니다.
<img width="643" height="235" alt="image" src="https://github.com/user-attachments/assets/76b09967-e009-4677-a60b-d1059600fe40" />


## Screenshot 📸
<img width="1200" height="645" alt="image" src="https://github.com/user-attachments/assets/a6884a34-b4ac-4cdd-b194-6958e84d4915" />
<img width="1200" height="635" alt="image" src="https://github.com/user-attachments/assets/fdafec42-34a9-4f7a-b4c2-bc89b6b6e4a7" />
<img width="1200" height="633" alt="image" src="https://github.com/user-attachments/assets/9b0b0fa1-a429-40ba-b9ea-43d132c11f9e" />


## Uncompleted Tasks 😅

## To Reviewers 📢
- 이러면 응답이 너무 길어지는 것 같아 걱정되는데... 괜찮으시겠죠? 제 딴에는 나름 층별로 찾기 쉬우시라고 Map을 채택한 건데, 만약 더 나은 방법이 있다면 알려주세요! 