### PR TITLE
[Refactor] 공지사항 크롤링 API 리팩터링

### DIFF
--- a/src/main/java/com/example/BarrierKU/domain/supportcenter/dto/NoticeResponse.java
+++ b/src/main/java/com/example/BarrierKU/domain/supportcenter/dto/NoticeResponse.java
@@ -8,7 +8,9 @@ public record NoticeResponse (
         @Schema(description = "날짜", example = "2025.07.30")
         String date,
         @Schema(description = "공지사항 url", example = "https://www.konkuk.ac.kr/csd/1234/subview.do?enc=Zm5j")
-        String url
+        String url,
+        @Schema(description = "번호", example = "13")
+        int number
 ) {
 
 }

--- a/src/main/java/com/example/BarrierKU/domain/supportcenter/service/NoticeService.java
+++ b/src/main/java/com/example/BarrierKU/domain/supportcenter/service/NoticeService.java
@@ -21,20 +21,21 @@ public class NoticeService {
 
     public List<NoticeResponse> getNotices() {
         List<NoticeResponse> notices = new ArrayList<>();
-        String siteUrl = "https://www.konkuk.ac.kr/sites/csd/index.do";
+        String siteUrl = "https://www.konkuk.ac.kr/csd/15238/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGY3NkJTJGNTM1JTJGYXJ0Y2xMaXN0LmRvJTNG";
 
         try {
             Document doc = Jsoup.connect(siteUrl).get();
-            Elements items = doc.select("div.list ul li a.subject");
+            Elements items = doc.select("tbody > tr:not(.notice)"); // 고정 공지 제외
 
             for (int i = 0; i < 3; i++) {
                 Element item = items.get(i);
 
-                String title = item.select(".subjectText span").text();
-                String date = item.select(".date").text();
-                String url = item.absUrl("href");
+                String title = item.select("td.td-subject a").text();
+                String date = item.select("td.td-date").text();
+                String url =  item.selectFirst("td.td-subject a").absUrl("href");
+                int number = Integer.parseInt(item.select("td.td-num").text());
 
-                notices.add(new NoticeResponse(title, date, url));
+                notices.add(new NoticeResponse(title, date, url, number));
             }
 
         } catch (IOException e) {


### PR DESCRIPTION
## Related issue 🛠
- closed #49 

## Work Description 📝
- 공지사항 번호를 추가하기 위해, 메인페이지에서 크롤링 -> 공지사항페이지에서 크롤링으로 변경

## Screenshot 📸
<img width="1755" height="934" alt="image" src="https://github.com/user-attachments/assets/ebd8fe17-d293-4d44-b2f9-ca02e3338ce6" />

## Uncompleted Tasks 😅

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 공지 목록에 게시글 번호가 추가로 표시됩니다.

- 버그 수정
  - 고정 공지를 제외하고 일반 공지만 노출되도록 목록 필터링을 개선했습니다.
  - 제목·날짜·링크 수집의 안정성을 높였습니다.

- 기타 개선
  - 공지 소스 페이지를 갱신해 링크 정확도를 향상했습니다.
  - 노출되는 항목 수는 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->