### PR TITLE
[Fix] 최단경로 길찾기 출발지 선택

### DIFF
--- a/src/main/java/com/example/BarrierKU/domain/door/repository/DoorRepository.java
+++ b/src/main/java/com/example/BarrierKU/domain/door/repository/DoorRepository.java
@@ -6,9 +6,31 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DoorRepository extends JpaRepository<Door, Long> {
+
+    @Query(value = """
+            SELECT d.spot
+            FROM door d
+            WHERE d.building_id = :buildingId
+            ORDER BY ST_DistanceSphere(d.spot, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
+            """, nativeQuery = true)
+    List<Point> findDoorSpotsByBuildingIdOrderByDistanceTo(@Param("buildingId") Long buildingId,
+                                                           @Param("lat") double lat,
+                                                           @Param("lon") double lon);
+
+    @Query(value = """
+            SELECT d.spot
+            FROM door d
+            WHERE d.building_id = :buildingId
+              AND d.wheelchair = true
+            ORDER BY ST_DistanceSphere(d.spot, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))
+            """, nativeQuery = true)
+    List<Point> findWheelchairDoorSpotsByBuildingIdOrderByDistanceTo(@Param("buildingId") Long buildingId,
+                                                                     @Param("lat") double lat,
+                                                                     @Param("lon") double lon);
 
     @Query(value = """
             SELECT d.spot

--- a/src/main/java/com/example/BarrierKU/domain/path/service/PathService.java
+++ b/src/main/java/com/example/BarrierKU/domain/path/service/PathService.java
@@ -20,7 +20,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.example.BarrierKU.common.response.ResponseCode.*;
 import static com.example.BarrierKU.domain.path.model.PathType.*;
@@ -40,6 +43,14 @@ public class PathService {
     private static final String BUILDING = "BUILDING";
     private static final String FACILITY = "FACILITY";
 
+    private record PathResult(GeoJsonFeatureCollection collection, double totalCost) {}
+
+    /**
+     * 출발 후보 정보: (문 좌표 lat, lon) + 해당 문과 가장 가까운 그래프 노드
+     * 여러 문이 같은 노드에 매핑될 수 있으므로, 노드 기준 중복 제거에 사용
+     */
+    private record StartCandidate(double lat, double lon, Node node) {}
+
     /**
      * 하나의 메서드에서 세 가지 경로 (최단, 계단 제외, 배리어프리)를 계산하고 응답 DTO 로 감싸 반환
      */
@@ -51,25 +62,82 @@ public class PathService {
             throw new BarrierKuException(SAME_SOURCE_AND_DESTINATION);
         }
 
-        Point srcPoint = getSpotByBuildingId(srcBuildingId);
-        double startLat = srcPoint.getY();
-        double startLon = srcPoint.getX();
-
-        Node startNode = findNearestNode(startLat, startLon);
-
-        GeoJsonFeatureCollection shortestPath = findPath(startLat, startLon, startNode, destBuildingId, SHORTEST);
-        GeoJsonFeatureCollection noStairsPath = findPath(startLat, startLon, startNode, destBuildingId, NO_STAIRS);
-        GeoJsonFeatureCollection barrierFreePath = findPath(startLat, startLon, startNode, destBuildingId, BARRIER_FREE);
+        GeoJsonFeatureCollection shortestPath = findPathWithDoorCandidates(srcBuildingId, destBuildingId, SHORTEST);
+        GeoJsonFeatureCollection noStairsPath = findPathWithDoorCandidates(srcBuildingId, destBuildingId, NO_STAIRS);
+        GeoJsonFeatureCollection barrierFreePath = findPathWithDoorCandidates(srcBuildingId, destBuildingId, BARRIER_FREE);
 
         return PathRecommendationsResponse.of(shortestPath, noStairsPath, barrierFreePath);
     }
 
+    /**
+     * 모든 경로 유형에 대해 출발지를 문 기반으로 통일하여 처리하는 로직
+     *
+     * 1. 출발 건물의 문들을 조회
+     * 2. 각 문에 대해 가장 가까운 그래프 노드를 찾고
+     * 3. 노드 기준으로 중복 제거
+     * 4. 각 시작 후보에 대해 경로 계산
+     * 5. 총 비용이 가장 작은 경로를 반환
+     */
+    private GeoJsonFeatureCollection findPathWithDoorCandidates(Long srcBuildingId, Long destBuildingId, PathType pathType) {
+        Point destCenter = getSpotByBuildingId(destBuildingId);
+        double destLat = destCenter.getY();
+        double destLon = destCenter.getX();
+
+        List<Point> doorSpots = resolveStartDoorSpots(srcBuildingId, destLat, destLon, pathType);
+        if (doorSpots.isEmpty()) {
+            throw new BarrierKuException(DOOR_NOT_FOUND);
+        }
+
+        List<StartCandidate> candidates = resolveDistinctStartCandidates(doorSpots);
+
+        return candidates.stream()
+                .map(c -> findPath(c.lat(), c.lon(), c.node(), destBuildingId, pathType))
+                .min(Comparator.comparingDouble(PathResult::totalCost))
+                .map(PathResult::collection)
+                .orElseGet(GeoJsonFactory::empty);
+    }
+
+    /**
+     * 경로 유형에 따라 출발 문 후보를 조회
+     *
+     * - SHORTEST: 모든 문 사용
+     * - NO_STAIRS / BARRIER_FREE:
+     *      휠체어 출입 가능 문 우선 사용
+     *      없을 경우 일반 문으로
+     */
+    private List<Point> resolveStartDoorSpots(Long srcBuildingId, double destLat, double destLon, PathType pathType) {
+        if (pathType == SHORTEST) {
+            return doorRepository.findDoorSpotsByBuildingIdOrderByDistanceTo(srcBuildingId, destLat, destLon);
+        }
+        List<Point> wheelchair = doorRepository.findWheelchairDoorSpotsByBuildingIdOrderByDistanceTo(
+                srcBuildingId, destLat, destLon);
+        if (!wheelchair.isEmpty()) {
+            return wheelchair;
+        }
+        return doorRepository.findDoorSpotsByBuildingIdOrderByDistanceTo(srcBuildingId, destLat, destLon);
+    }
+
+    /**
+     * 문 좌표 리스트를 시작 후보로 변환
+     *
+     * 여러 문이 동일한 그래프 노드에 매핑될 수 있으므로,
+     * 노드 UID 기준으로 중복 제거하여 하나만 유지
+     */
+    private List<StartCandidate> resolveDistinctStartCandidates(List<Point> doorSpots) {
+        Map<String, StartCandidate> byNodeUid = new LinkedHashMap<>();
+        for (Point spot : doorSpots) {
+            double lat = spot.getY();
+            double lon = spot.getX();
+            Node node = findNearestNode(lat, lon);
+            byNodeUid.putIfAbsent(node.getUid(), new StartCandidate(lat, lon, node));
+        }
+        return new ArrayList<>(byNodeUid.values());
+    }
 
     /**
      * 실제 경로를 탐색하는 로직 (경로 유형에 따라 도착지 결정 및 SQL 분기)
      */
-    // 추가 메서드 예시(파일 내 임의 위치)
-    private GeoJsonFeatureCollection findPath(double startLat, double startLon, Node startNode, Long destBuildingId, PathType pathType) {
+    private PathResult findPath(double startLat, double startLon, Node startNode, Long destBuildingId, PathType pathType) {
         Point destPoint = getBestDoorSpot(destBuildingId, startLat, startLon, pathType);
         double endLat = destPoint.getY();
         double endLon = destPoint.getX();
@@ -112,18 +180,20 @@ public class PathService {
         });
 
         if (edges.isEmpty()) {
-            return GeoJsonFactory.empty();
+            return new PathResult(GeoJsonFactory.empty(), Double.MAX_VALUE);
         }
 
         double startPointToStartNodeDistance = getDistanceFromPointToNode(startLon, startLat, startNode.getUid());
         double endNodeToEndPointDistance     = getDistanceFromPointToNode(endLon, endLat, endNode.getUid());
+        double totalCost = startPointToStartNodeDistance + endNodeToEndPointDistance
+                + edges.stream().mapToDouble(GraphEdge::weight).sum();
 
-        return GeoJsonFactory.fromEdges(
+        GeoJsonFeatureCollection collection = GeoJsonFactory.fromEdges(
                 edges, startLat, startLon, endLat, endLon,
                 startPointToStartNodeDistance, endNodeToEndPointDistance
         );
+        return new PathResult(collection, totalCost);
     }
-
 
     /**
      * 경로 유형(PathType)에 따라 휠체어 가능 문을 우선 고려하되, 없을 경우 일반 문 중에서 선택


### PR DESCRIPTION
## Related issue 🛠
- closed #67 

## Work Description 📝
- 건물 좌표에서 가장 가까운 노드를 출발 노드로 하면 도착지에 상관 없이 항상 같은 노드가 선택됨. 도착지의 방향에 따라 최단 경로는 달라지고, 건물좌표->가장가까운노드는 실제로 존재하지 않는 길인 경우도 있음.
- 출발 노드를 문으로 변경하고 모든 문을 탐색해서 최단경로인 문을 선택. 계단 없는 경로나 배리어프리 타입은 휠체어 문 우선 탐색.

## Screenshot 📸

## Uncompleted Tasks 😅

## To Reviewers 📢
